### PR TITLE
Check for null identifiers from destructured arguments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -625,6 +625,14 @@ function getAllIdentifiers(nodes) {
 	var ret = [];
 
 	for (let node of nodes) {
+
+		// Because parameters in destructured arrays may be omitted,
+		// returning `null`, we continue as if nothing happened.
+		// Not type-checking `null`, in case `node` is `undefined`.
+		if (node == null) {
+			continue;
+		}
+
 		if (node.type == "Identifier") {
 			ret = [ ...ret, node, ];
 		}

--- a/lib/index.js
+++ b/lib/index.js
@@ -626,10 +626,9 @@ function getAllIdentifiers(nodes) {
 
 	for (let node of nodes) {
 
-		// Because parameters in destructured arrays may be omitted,
-		// returning `null`, we continue as if nothing happened.
-		// Not type-checking `null`, in case `node` is `undefined`.
-		if (node == null) {
+		// Parameters in destructured arrays may be omitted, returning 
+		// `null` on iteration. Continue as if nothing happened.
+		if (node === null) {
 			continue;
 		}
 


### PR DESCRIPTION
Ref issue #16. 

The following function will cause the plugin to fail, as the omitted first parameter will return `null`.
```js
function something([, y]) {
  console.log(y);
}

something([1, 2]);
```
This fix contains an added check for `null` in `getAllIdentifiers()`.
