### PR TITLE
Include modulescope in global

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The rules defined in this plugin:
 
    **Note:** This rule is like the "as-needed" mode of the [built-in ESLint "func-names" rule](https://eslint.org/docs/rules/func-names), but applied to `=>` arrow functions; the built-in rule ignores them.
 
-* [`"where"`](#rule-where): restricts where in program structure `=>` arrow functions can be used: forbidding them in the top-level/global scope, object properties, `export` statements, etc.
+* [`"where"`](#rule-where): restricts where in program structure `=>` arrow functions can be used: forbidding them in the global/top-level-module scope, object properties, `export` statements, etc.
 
 * [`"return"`](#rule-return): restricts the concise return value kind for `=>` arrow functions, such as forbidding object literal concise returns (`x => ({ x })`), forbidding concise returns of conditional/ternary expressions (`x => x ? y : z`), etc.
 
@@ -465,7 +465,7 @@ In this snippet, all three `=>` arrow functions remain anonymous because no name
 
 The **proper-arrows**/*where* rule restricts where in program structure `=>` arrow functions can be used.
 
-This rule can be configured to forbid `=>` arrow functions in the top-level/global scope (`"global"`), forbid `=>` arrow functions as object properties (`"property"`), and forbid `=>` arrow functions in `export` statements (`"export"`).
+This rule can be configured to forbid `=>` arrow functions in the global/top-level-module scope (`"global"`), forbid `=>` arrow functions as object properties (`"property"`), and forbid `=>` arrow functions in `export` statements (`"export"`).
 
 To turn this rule on:
 
@@ -479,7 +479,7 @@ To turn this rule on:
 
 The main purpose of this rule is to avoid readability harm when using `=>` arrow functions in certain program structure locations.
 
-Placing `=>` arrow functions in the top-level/global scope has no benefit other than preferred style; they're more proper as regular function declarations. Placing `=>` arrow functions on object properties has no benefit other than preferred style; they're more proper as concise object methods. Placing arrow functions in `export` statements offers no benefit other than being more concise; they're more proper as exported named function declarations.
+Placing `=>` arrow functions in the global/top-level-module scope has no benefit other than preferred style; they're more proper as regular function declarations. Placing `=>` arrow functions on object properties has no benefit other than preferred style; they're more proper as concise object methods. Placing arrow functions in `export` statements offers no benefit other than being more concise; they're more proper as exported named function declarations.
 
 For example:
 
@@ -527,7 +527,7 @@ The **proper-arrows**/*where* rule can be configured with three (non-exclusive) 
 
 **Note:** The default behavior is that all three modes are turned on for this rule. You must specifically configure each mode to disable it.
 
-* [`"global"`](#rule-where-configuration-global) (default: `true`) forbids `=>` arrow functions in the top-level/global scope.
+* [`"global"`](#rule-where-configuration-global) (default: `true`) forbids `=>` arrow functions in the global/top-level-module scope.
 
 * [`"property"`](#rule-where-configuration-property) (default: `true`) forbids assigning `=>` arrow functions to object properties.
 
@@ -541,7 +541,7 @@ To configure this rule mode (on by default, set as `false` to turn off):
 "@getify/proper-arrows/where": [ "error", { "global": true, "trivial": false } ]
 ```
 
-When defining functions at the top-level/global scope, use a regular function declaration:
+When defining functions at the global/top-level-module scope, use a regular function declaration:
 
 ```js
 function onData(data) {
@@ -870,11 +870,11 @@ The **proper-arrows**/*this* rule can be configured in one of three modes: `"nes
 
 * [`"nested"`](#rule-this-configuration-nested) (default) permits a `this` to appear lower in a nested `=>` arrow function (i.e., `x = y => z => this.foo(z)`), as long as there is no non-arrow function boundary crossed.
 
-   Additionally, include the `"no-global"` option (default: `false`) to forbid `this`-containing `=>` arrow functions from the top-level scope (where they might inherit the global object as `this`).
+   Additionally, include the `"no-global"` option (default: `false`) to forbid `this`-containing `=>` arrow functions from the global scope (where they might inherit the global object as `this`) or from the top-level of a module (where `this` would be `undefined`).
 
 * [`"always"`](#rule-this-configuration-always) is more strict, requiring every single `=>` arrow function to have its own `this` reference.
 
-   Additionally, include the `"no-global"` option (default: `false`) to forbid `this`-containing `=>` arrow functions from the top-level scope (where they might inherit the global object as `this`).
+   Additionally, include the `"no-global"` option (default: `false`) to forbid `this`-containing `=>` arrow functions from the global scope (where they might inherit the global object as `this`) or from the top-level of a module (where `this` would be `undefined`).
 
 * [`"never"`](#rule-this-configuration-never) is the reverse of the rule: all `=>` arrow functions are forbidden from using `this`.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -266,7 +266,7 @@ module.exports = {
 					},
 				],
 				messages: {
-					noGlobal: "Arrow function not allowed in global/top-level scope",
+					noGlobal: "Arrow function not allowed in global/top-level-module scope",
 					noProperty: "Arrow function not allowed in object property",
 					noExport: "Arrow function not allowed in 'export' statement",
 				},

--- a/lib/index.js
+++ b/lib/index.js
@@ -727,12 +727,12 @@ function currentlyInGlobalScope(parserOptions,scope) {
 			extraGlobalScope &&
 			scope.upper &&
 			scope.upper.upper &&
-			scope.upper.upper.type == "global"
+			["global","module"].includes(scope.upper.upper.type)
 		) ||
 		(
 			!extraGlobalScope &&
 			scope.upper &&
-			scope.upper.type == "global"
+			["global","module"].includes(scope.upper.type)
 		)
 	);
 }

--- a/tests/tests.trivial.js
+++ b/tests/tests.trivial.js
@@ -215,10 +215,15 @@ QUnit.test( "TRIVIAL (module-export, trivial:true): violating", function test(as
 	var results = eslinter.verify( code, linterOptions.trivialModule );
 
 	assert.expect( 1 );
-	var [{ ruleId, messageId, } = {},] = results || [];
+	var [
+		{ ruleId: ruleId1, messageId: messageId1, } = {},
+		{ ruleId: ruleId2, messageId: messageId2, } = {},
+	] = results || [];
 
-	assert.expect( 3 );
-	assert.strictEqual( results.length, 1, "only 1 error" );
-	assert.strictEqual( ruleId, "@getify/proper-arrows/where", "ruleId" );
-	assert.strictEqual( messageId, "noExport", "messageId" );
+	assert.expect( 5 );
+	assert.strictEqual( results.length, 2, "only 2 error" );
+	assert.strictEqual( ruleId1, "@getify/proper-arrows/where", "ruleId" );
+	assert.strictEqual( messageId1, "noGlobal", "messageId" );
+	assert.strictEqual( ruleId2, "@getify/proper-arrows/where", "ruleId" );
+	assert.strictEqual( messageId2, "noExport", "messageId" );
 } );

--- a/tests/tests.trivial.js
+++ b/tests/tests.trivial.js
@@ -214,7 +214,6 @@ QUnit.test( "TRIVIAL (module-export, trivial:true): violating", function test(as
 
 	var results = eslinter.verify( code, linterOptions.trivialModule );
 
-	assert.expect( 1 );
 	var [
 		{ ruleId: ruleId1, messageId: messageId1, } = {},
 		{ ruleId: ruleId2, messageId: messageId2, } = {},

--- a/tests/tests.where.js
+++ b/tests/tests.where.js
@@ -13,6 +13,14 @@ var linterOptions = {
 		parserOptions: { ecmaVersion: 2015, },
 		rules: { "@getify/proper-arrows/where": ["error",{global:true,property:false,export:false,trivial:true,},], },
 	},
+	whereModuleGlobalDefault: {
+		parserOptions: { ecmaVersion: 2015, sourceType: "module", },
+		rules: { "@getify/proper-arrows/where": ["error",{property:false,export:false,trivial:true,},], },
+	},
+	whereModuleGlobal: {
+		parserOptions: { ecmaVersion: 2015, sourceType: "module", },
+		rules: { "@getify/proper-arrows/where": ["error",{global:true,property:false,export:false,trivial:true,},], },
+	},
 	wherePropertyDefault: {
 		parserOptions: { ecmaVersion: 2015, },
 		rules: { "@getify/proper-arrows/where": ["error",{global:false,export:false,trivial:true,},], },
@@ -114,6 +122,60 @@ QUnit.test( "WHERE (global): violating", function test(assert){
 	`;
 
 	var results = eslinter.verify( code, linterOptions.whereGlobal );
+	var [{ ruleId, messageId, } = {},] = results || [];
+
+	assert.expect( 3 );
+	assert.strictEqual( results.length, 1, "only 1 error" );
+	assert.strictEqual( ruleId, "@getify/proper-arrows/where", "ruleId" );
+	assert.strictEqual( messageId, "noGlobal", "messageId" );
+} );
+
+QUnit.test( "WHERE (module-global, default): conforming", function test(assert){
+	var code = `
+		function foo() {
+			var f = x => y;
+		}
+	`;
+
+	var results = eslinter.verify( code, linterOptions.whereModuleGlobalDefault );
+
+	assert.expect( 1 );
+	assert.strictEqual( results.length, 0, "no errors" );
+} );
+
+QUnit.test( "WHERE (module-global, default): violating", function test(assert){
+	var code = `
+		var f = x => y;
+	`;
+
+	var results = eslinter.verify( code, linterOptions.whereModuleGlobalDefault );
+	var [{ ruleId, messageId, } = {},] = results || [];
+
+	assert.expect( 3 );
+	assert.strictEqual( results.length, 1, "only 1 error" );
+	assert.strictEqual( ruleId, "@getify/proper-arrows/where", "ruleId" );
+	assert.strictEqual( messageId, "noGlobal", "messageId" );
+} );
+
+QUnit.test( "WHERE (module-global): conforming", function test(assert){
+	var code = `
+		function foo() {
+			var f = x => y;
+		}
+	`;
+
+	var results = eslinter.verify( code, linterOptions.whereModuleGlobal );
+
+	assert.expect( 1 );
+	assert.strictEqual( results.length, 0, "no errors" );
+} );
+
+QUnit.test( "WHERE (module-global): violating", function test(assert){
+	var code = `
+		var f = x => y;
+	`;
+
+	var results = eslinter.verify( code, linterOptions.whereModuleGlobal );
 	var [{ ruleId, messageId, } = {},] = results || [];
 
 	assert.expect( 3 );


### PR DESCRIPTION
Pull-request for #29, `where` rule now identifies arrow-functions in module-top-level scope as well as global scope.