### PR TITLE
Make trivial conditions configurable and add optional support for more AST

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,44 @@ By default, **all rules ignore** these trivial functions. To **force a rule to c
 
 **Note:** The `"trivial"` option **will not necessarily report** trivial functions, but it will force trivial functions to be checked by the rule/mode in question.
 
+#### Configuring Triviality
+
+The default values for what constitutes a trivial function have some flexibility and can be altered via a `proper-arrows/trivial` settings entry in your `.eslintrc` file:
+
+```json
+{
+    "settings": {
+        "proper-arrows/trivial": {
+            "maxParamCount": 1,
+            "maxBlockStatements": 0, 
+            "maxMemberDepth": 0,
+            "maxObjectParamKeys": 0,
+            "maxArrayParamKeys": 0,
+            "allowVoid": true,
+            "allowNot": false,
+            "allowDoubleNot": false,
+            "allowBinaryExpression": false,
+            "allowedOperators": ["+", "-", "/", "*", "^", "%"],
+            "allowCallExpression": false,
+            "allowedCallArguments": 1
+        }
+    }
+}
+```
+
+- `maxParamCount`:  Maximum allowed arguments for the arrow function to be trivial.
+- `maxBlockStatements`: Maximum number of statements allowed inside a block function. Set to -1 to disallow empty block statements.
+- `maxMemberDepth`: Maximum depth of member elements on a variable (eg: a.b.c would require 3)
+- `maxObjectParamKeys`: Maximum allowed number of keys referenced in an object parameter (eg: `({a, b}) => {}` is 2)
+- `maxArrayParamKeys`: Maximum allowed number of indexes referenced in an array parameter (eg: `([a, b]) => {}` is 2)
+- `allowVoid`: Allow as a trivial `void 0` for a function body.
+- `allowNot`: Allow `!argument` as a function body.
+- `allowDoubleNot`: Allow `!!argument` as a function body (boolean coercion)
+- `allowBinaryExpression`: Allow two-part operators (eg: `n * n`) as a function body.
+- `allowedOperators`: Array of the allowed operators for binary expressions.
+- `allowCallExpression`: Allow invocation of functions (eg: `(s) => someFunction(s, 2)`)
+- `allowedCallArguments`: Number of allowed arguments in an invoked function for it to remain trivial.
+
 ## Enabling The Plugin
 
 To use **proper-arrows**, load it as a plugin into ESLint and configure the rules as desired.

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,7 @@ module.exports = {
 				return {
 					"ArrowFunctionExpression:exit": function exit(node) {
 						// ignore a trivial arrow function?
-						if (ignoreTrivial && isTrivialArrow(node)) {
+						if (ignoreTrivial && isTrivialArrow(node, getSettings(context))) {
 							return;
 						}
 
@@ -226,7 +226,7 @@ module.exports = {
 				return {
 					"ArrowFunctionExpression": function exit(node) {
 						// ignore a trivial arrow function?
-						if (ignoreTrivial && isTrivialArrow(node)) {
+						if (ignoreTrivial && isTrivialArrow(node, getSettings(context))) {
 							return;
 						}
 
@@ -297,7 +297,7 @@ module.exports = {
 				return {
 					"ArrowFunctionExpression": function exit(node) {
 						// ignore a trivial arrow function?
-						if (ignoreTrivial && isTrivialArrow(node)) {
+						if (ignoreTrivial && isTrivialArrow(node, getSettings(context))) {
 							return;
 						}
 
@@ -430,7 +430,7 @@ module.exports = {
 					},
 					"ArrowFunctionExpression": function enter(node) {
 						// ignore a trivial arrow function?
-						if (ignoreTrivial && isTrivialArrow(node)) {
+						if (ignoreTrivial && isTrivialArrow(node, getSettings(context))) {
 							return;
 						}
 
@@ -464,7 +464,7 @@ module.exports = {
 							node.body.type == "ArrowFunctionExpression"
 						) {
 							// ignore a trivial arrow function?
-							if (ignoreTrivial && isTrivialArrow(node.body)) {
+							if (ignoreTrivial && isTrivialArrow(node.body, getSettings(context))) {
 								return;
 							}
 
@@ -490,7 +490,7 @@ module.exports = {
 					},
 					"ArrowFunctionExpression:exit": function exit(node) {
 						// ignore a trivial arrow function?
-						if (ignoreTrivial && isTrivialArrow(node)) {
+						if (ignoreTrivial && isTrivialArrow(node, getSettings(context))) {
 							return;
 						}
 
@@ -567,7 +567,7 @@ module.exports = {
 					},
 					"ArrowFunctionExpression:exit": function exit(node) {
 						// ignore a trivial arrow function?
-						if (ignoreTrivial && isTrivialArrow(node)) {
+						if (ignoreTrivial && isTrivialArrow(node, getSettings(context))) {
 							return;
 						}
 
@@ -747,43 +747,118 @@ function inArrowParams(id,func) {
 	);
 }
 
-function isTrivialArrow(node) {
+function isTrivialArrow(node, { trivial }) {
 	return (
 		node.type == "ArrowFunctionExpression" &&
-		node.params.length <= 1 &&
+		node.params.length <= trivial.maxParamCount &&
 		(
 			node.params.length == 0 ||
-			node.params[0].type == "Identifier"
+			node.params.every(function paramTypeCheck ({ type, properties, elements }) {
+				return (
+					(type == "Identifier") ||
+					(
+						trivial.maxObjectParamKeys &&
+						type == 'ObjectPattern' &&
+						properties.length <= trivial.maxObjectParamKeys
+					) ||
+					(
+						trivial.maxArrayParamKeys &&
+						type == 'ArrayPattern' &&
+						elements.length <= trivial.maxArrayParamKeys
+					)
+				)
+			})
 		) &&
-		(
-			// .. => {}
-			(
-				node.body.type == "BlockStatement" &&
-				node.body.body.length == 0
-			) ||
+		Object.values(TrivialBodyConditions).some((condition) => condition(node.body, trivial))
+	);
+}
+
+var TrivialBodyConditions = {
+	BlockStatement ({ type, body }, { maxBlockStatements }) {
+		return (
+			maxBlockStatements > -1 &&
+			type == "BlockStatement" &&
+			body.length == maxBlockStatements
+		);
+	},
+	Literal ({ type, value }) {
+		return (
 			// .. => --literal--
 			(
-				node.body.type == "Literal" &&
-				["number","string","boolean",].includes(typeof node.body.value)
+				type == "Literal" &&
+				["number","string","boolean",].includes(typeof value)
 			) ||
 			// .. => null
 			(
-				node.body.type == "Literal" &&
-				node.body.value === null
-			) ||
-			// .. => undefined   OR   .. => x
+				type == "Literal" &&
+				value === null
+			)
+		);
+	},
+	Identifier (node, { maxMemberDepth }) {
+		return (
 			(
-				node.body.type == "Identifier"
+				node.type == "Identifier"
 			) ||
-			// .. => void ..
 			(
-				node.body.type == "UnaryExpression" &&
-				node.body.operator == "void" &&
-				node.body.argument.type == "Literal"
+				maxMemberDepth >= 1 &&
+				node.type == "MemberExpression" &&
+				TrivialBodyConditions.Identifier(node.object, {
+					maxMemberDepth: maxMemberDepth - 1
+				}) &&
+				TrivialBodyConditions.Identifier(node.property, {
+					maxMemberDepth: maxMemberDepth - 1
+				})
 			)
 		)
-	);
-}
+	},
+	Void (node, { allowVoid }) {
+		return allowVoid && (
+			node.type == "UnaryExpression" &&
+			node.operator == "void" &&
+			node.argument.type == "Literal"
+		);
+	},
+	Not (node, { allowNot, maxMemberDepth }) {
+		return allowNot && (
+			node.type == "UnaryExpression" &&
+			node.operator == "!" &&
+			TrivialBodyConditions.Identifier(node.argument, { maxMemberDepth })
+		);
+	},
+	DoubleNot (node, { allowDoubleNot, maxMemberDepth }) {
+		return allowDoubleNot && (
+			node.type == "UnaryExpression" &&
+			node.operator == "!" &&
+			node.argument.type == "UnaryExpression" &&
+			node.argument.operator == "!" &&
+			( node.argument.argument.type == "Literal" || TrivialBodyConditions.Identifier(node.argument.argument, { maxMemberDepth }) )
+		);
+	},
+	BinaryExpression (node, { allowBinaryExpression, allowedOperators, maxMemberDepth }) {
+		return allowBinaryExpression && (
+			node.type == "BinaryExpression" &&
+			allowedOperators.includes(node.operator) &&
+			( node.left.type == "Literal" || TrivialBodyConditions.Identifier(node.left, { maxMemberDepth }) ) &&
+			( node.right.type == "Literal" || TrivialBodyConditions.Identifier(node.right, { maxMemberDepth }) )
+		)
+	},
+	CallExpression (node, {
+		allowCallExpression,
+		allowedCallArguments,
+		maxMemberDepth
+	}) {
+		return allowCallExpression && (
+			node.type == "CallExpression" &&
+			TrivialBodyConditions.Identifier(node.callee, { maxMemberDepth }) &&
+			node.arguments.length <= allowedCallArguments &&
+			node.arguments.every(function argsAreValid (arg) {
+				return TrivialBodyConditions.Identifier(arg, { maxMemberDepth }) ||
+					TrivialBodyConditions.Literal(arg, { maxMemberDepth });
+			})
+		)
+	}
+};
 
 function currentlyInGlobalScope(parserOptions,scope) {
 	var extraGlobalScope = parserOptions.ecmaFeatures && parserOptions.ecmaFeatures.globalReturn;
@@ -800,4 +875,37 @@ function currentlyInGlobalScope(parserOptions,scope) {
 			["global","module"].includes(scope.upper.type)
 		)
 	);
+}
+
+function getSettings(context) {
+	const {
+		maxParamCount = 1,
+		maxBlockStatements = 0,
+		maxMemberDepth = 0,
+		maxObjectParamKeys = 0,
+		maxArrayParamKeys = 0,
+		allowVoid = true,
+		allowNot = false,
+		allowDoubleNot = false,
+		allowBinaryExpression = false,
+		allowedOperators = ["+", "-", "/", "*", "^", "%"],
+		allowCallExpression = false,
+		allowedCallArguments = 1
+	} = context.settings['proper-arrows/trivial'] || {};
+	return {
+		trivial: {
+			maxParamCount,
+			maxBlockStatements,
+			maxMemberDepth,
+			maxObjectParamKeys,
+			maxArrayParamKeys,
+			allowVoid,
+			allowNot,
+			allowDoubleNot,
+			allowBinaryExpression,
+			allowedOperators,
+			allowCallExpression,
+			allowedCallArguments
+		}
+	};
 }


### PR DESCRIPTION
We wanted a plugin to enforce named functions across our codebase where appropriate for our needs, but found the conditions for what's considered trivial to be a little too restrictive. So I made it configurable!